### PR TITLE
fix(slider): retrieve value from attribute first

### DIFF
--- a/packages/wired-slider/src/wired-slider.ts
+++ b/packages/wired-slider/src/wired-slider.ts
@@ -109,7 +109,7 @@ export class WiredSlider extends WiredBase {
   }
 
   firstUpdated() {
-    this.value = this.pendingValue || this.value || +(this.getAttribute('value') || this.min);
+    this.value = this.pendingValue || +(this.getAttribute('value') || this.value || this.min);
     delete this.pendingValue;
   }
 


### PR DESCRIPTION
Fix #121 